### PR TITLE
docker-publish.yml only works on template repository

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -15,6 +15,7 @@ env:
 
 jobs:
   build:
+    if: github.repository == 'sotashimozono/template.jl'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## 概要
(もしあれば)
- 関連するIssue: #

## 変更の種類
- [ ] ✨ 新機能 (Feature)
- [ ] 🐛 バグ修正 (Bug Fix)
- [ ] ⚡ パフォーマンス改善 (Performance)
- [ ] 📖 ドキュメント整備 (Documentation)
- [ ] 🔧 その他 (Refactoring, CI/CD, etc...)

## 変更内容
- init.ymlがdocker imageの構築とかを走らせてしまうので、docker-publishをtemplate.jlでのみ実行するように変更した
- 

## 使用例
```julia
# 実装した機能の使用例

```
## check list
- [ ] test駆動をしたか
- [ ] Project.tomlのバージョンを上げたか
