### PR TITLE
ci: accelerate CompatHelper + AutoMerge (cron 6x faster, squash + delete-branch)

### DIFF
--- a/.github/workflows/AutoMerge.yml
+++ b/.github/workflows/AutoMerge.yml
@@ -2,7 +2,7 @@ name: AutoMerge
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, labeled] # label反応も入れると便利
+    types: [opened, synchronize, reopened, labeled]
 
 permissions:
   contents: write
@@ -15,8 +15,11 @@ jobs:
       github.event.pull_request.user.type == 'Bot' ||
       contains(github.event.pull_request.labels.*.name, 'automerge')
     steps:
-      - name: Enable auto-merge
+      - name: Enable auto-merge (squash, delete branch)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_URL: ${{ github.event.pull_request.html_url }}
-        run: gh pr merge --auto --merge "$PR_URL"
+        # `--auto` + `--squash` で必要 check が green になった瞬間に squash-merge し、
+        # `--delete-branch` で bot 用の throwaway branch を即削除する。
+        # Bot PR (CompatHelper / dependabot / TagBot 等) を 1 step で完結させる。
+        run: gh pr merge --auto --squash --delete-branch "$PR_URL"

--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -1,12 +1,18 @@
 name: CompatHelper
 on:
   schedule:
-    - cron: '0 0 * * *' # 毎日0時にチェック
+    # 4 時間ごとにチェック (旧: 毎日 0 時) — bot PR の遅延を 1/6 に短縮
+    - cron: '0 */4 * * *'
   workflow_dispatch:
 
 permissions:
   contents: write
   pull-requests: write
+
+# 同一 ref に対する重複起動を抑止 (manual + cron が重なるケース)
+concurrency:
+  group: compathelper
+  cancel-in-progress: false
 
 jobs:
   CompatHelper:


### PR DESCRIPTION
CompatHelper.yml: cron `0 0 * * *` (daily) -> `0 */4 * * *` (every 4h) + concurrency group.\n\nAutoMerge.yml: `gh pr merge --auto --merge` -> `gh pr merge --auto --squash --delete-branch`.\n\nNet effect: bot PR creation latency drops ~6x and merged bot branches are auto-cleaned. Safe for non-chain bot PRs (CompatHelper / dependabot / TagBot).