### PR TITLE
ci: hard-gate reference check via doiget verify

### DIFF
--- a/.github/scripts/verify_references_gate.py
+++ b/.github/scripts/verify_references_gate.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""Gate `doiget verify` output against an allowlist and emit a Markdown report.
+
+Reads doiget's JSON-Lines `verify` output on stdin (one record per reference,
+with a `status` field), plus an optional allowlist file. Classifies each entry:
+
+    valid                        -> OK, resolves on Crossref / arXiv
+    illegal | absent             -> BROKEN: malformed id, or does not resolve
+                                    (fabricated / mistyped / not indexed)
+    unreachable | unverifiable   -> TRANSIENT: network / 429 / no-id / coverage
+                                    gap; NOT gated (would make CI flaky)
+
+A BROKEN entry fails the gate (exit 1) UNLESS its DOI / arXiv id *or* its bibkey
+appears in the allowlist — i.e. a human has explicitly vouched for it. The
+allowlist (`docs/references.allow` by default) is one id/key per line, `#` starts
+a comment; put the reason in the comment so every exception is self-documenting.
+
+Completeness (the "no verification left out" guarantee): when `--bib` is given,
+every reference entry in the bibliography must have produced a verify record. If
+doiget aborted, timed out, or skipped an entry, that entry is UNVERIFIED and
+fails the gate — a truncated run can never masquerade as a clean one. Unverified
+entries are NOT allowlist-downgradable (the check simply did not run).
+
+So a reference that does not exist — or that was never checked at all — can never
+pass silently. Always writes a Markdown report (for the PR comment / job summary)
+regardless of outcome.
+
+Usage (also runnable locally):
+    doiget verify docs/references.bib --mode json \\
+      | python3 .github/scripts/verify_references_gate.py \\
+          --bib docs/references.bib --allow docs/references.allow
+"""
+import argparse
+import json
+import os
+import re
+import sys
+
+BROKEN = {"illegal", "absent"}
+TRANSIENT = {"unreachable", "unverifiable"}
+
+# `@type{key,` — a reference entry. @comment / @string / @preamble / @set are
+# BibTeX machinery, not references, so they are excluded from the completeness count.
+_ENTRY_RE = re.compile(r"@(\w+)\s*\{\s*([^,\s}]+)", re.IGNORECASE)
+_NON_REF_TYPES = {"comment", "string", "preamble", "set"}
+
+
+def load_allow(path):
+    allow = set()
+    if path and os.path.exists(path):
+        with open(path, encoding="utf-8") as fh:
+            for line in fh:
+                token = line.split("#", 1)[0].strip()
+                if token:
+                    allow.add(token.lower())
+    return allow
+
+
+def bib_keys(path):
+    keys = []
+    if path and os.path.exists(path):
+        with open(path, encoding="utf-8") as fh:
+            for m in _ENTRY_RE.finditer(fh.read()):
+                if m.group(1).lower() not in _NON_REF_TYPES:
+                    keys.append(m.group(2))
+    return keys
+
+
+def detail_of(entry):
+    err = entry.get("error")
+    if isinstance(err, dict):
+        return str(err.get("message", ""))[:90]
+    return ""
+
+
+def render(ok, transient, excepted, broken, unverified):
+    out = ["<!-- verify-references-gate -->", "## Reference check — `doiget verify`", ""]
+    out.append(f"- ✅ resolved: **{len(ok)}**")
+    if transient:
+        out.append(f"- ⚠️ transient (network / no-id / not-yet-indexed — not gated): **{len(transient)}**")
+    if excepted:
+        out.append(f"- 🟡 allowlisted exceptions: **{len(excepted)}**")
+    out.append(f"- {'❌' if broken else '☑️'} broken (unresolved / malformed): **{len(broken)}**")
+    if unverified:
+        out.append(f"- ❌ unverified (no record — check did not run): **{len(unverified)}**")
+    out.append("")
+
+    def table(title, rows):
+        if not rows:
+            return []
+        block = [f"### {title}", "", "| bibkey | ref | status | detail |", "|---|---|---|---|"]
+        for e in rows:
+            block.append(
+                f"| `{e.get('entry_key') or ''}` | `{e.get('ref') or ''}` | "
+                f"{e.get('status') or ''} | {detail_of(e)} |"
+            )
+        block.append("")
+        return block
+
+    out += table("❌ Broken references — fix the id, or add an explicit exception", broken)
+    if unverified:
+        out += ["### ❌ Unverified references — the check did not run on these", ""]
+        out += ["| bibkey |", "|---|"]
+        out += [f"| `{k}` |" for k in unverified]
+        out += [""]
+    out += table("⚠️ Transient (not gated)", transient)
+    out += table("🟡 Allowlisted exceptions", excepted)
+
+    if broken:
+        out += [
+            "A broken reference does not resolve on Crossref / arXiv — it is "
+            "**fabricated**, mistyped, or genuinely not indexed. Fix the id in the "
+            "bibliography, or, if it is real but unresolvable, add its DOI / arXiv id "
+            "(or bibkey) to `docs/references.allow` **with a comment saying why**.",
+            "",
+        ]
+    if unverified:
+        out += [
+            "An unverified reference produced no result — doiget aborted, timed out, "
+            "or could not parse it, so it was **never checked**. Re-run the job; if it "
+            "persists, the bibliography entry is malformed. This is not allowlistable — "
+            "the point is that every reference is actually verified.",
+            "",
+        ]
+    return "\n".join(out)
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--bib", default="", help="bibliography path, for the completeness check")
+    ap.add_argument("--allow", default="docs/references.allow", help="allowlist file")
+    ap.add_argument("--report", default="", help="write the Markdown report to this path")
+    ap.add_argument("--github-output", default="", help="write broken=/unverified=/fail=/ok= here")
+    args = ap.parse_args()
+
+    allow = load_allow(args.allow)
+
+    ok, transient, excepted, broken = [], [], [], []
+    seen = set()
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            entry = json.loads(line)
+        except json.JSONDecodeError:
+            continue  # skip any non-JSON human-summary line
+        if not isinstance(entry, dict) or "status" not in entry:
+            continue
+        # `ref` is JSON null for id-less entries, so `.get(k, "")` returns None,
+        # not "" — coerce with `or ""` before touching .lower().
+        key = (entry.get("entry_key") or "").lower()
+        ref = (entry.get("ref") or "").lower()
+        seen.add(key)
+        status = entry.get("status", "")
+        allowed = ref in allow or key in allow
+        if status in BROKEN:
+            (excepted if allowed else broken).append(entry)
+        elif status in TRANSIENT:
+            transient.append(entry)
+        else:
+            ok.append(entry)
+
+    # Completeness: every reference entry in the bib must have a verify record.
+    unverified = [k for k in bib_keys(args.bib) if k.lower() not in seen]
+
+    report = render(ok, transient, excepted, broken, unverified)
+    if args.report:
+        with open(args.report, "w", encoding="utf-8") as fh:
+            fh.write(report + "\n")
+    fail = len(broken) + len(unverified)
+    if args.github_output:
+        with open(args.github_output, "a", encoding="utf-8") as fh:
+            fh.write(
+                f"broken={len(broken)}\nunverified={len(unverified)}\n"
+                f"fail={fail}\nok={len(ok)}\ntransient={len(transient)}\n"
+            )
+    print(report)
+
+    return 1 if fail else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/VerifyReferences.yml
+++ b/.github/workflows/VerifyReferences.yml
@@ -1,0 +1,103 @@
+name: Verify references
+
+# Reference / citation check: every DOI / arXiv id in docs/references.bib must
+# resolve to real metadata (Crossref / arXiv) via `doiget verify`, or the check
+# FAILS. A reference that does not exist can never pass silently — it either
+# fails here or is explicitly excepted in docs/references.allow (with a reason).
+# The full result is posted as a sticky PR comment AND the job summary, so a
+# broken citation is visible without opening the CI logs.
+#
+# Gating (the authority is .github/scripts/verify_references_gate.py, not
+# doiget's own exit code):
+#   illegal | absent            -> FAIL   (malformed, or does not resolve)
+#   unreachable | unverifiable  -> warn   (transient network / 429; not gated,
+#                                          so infra flakiness never blocks a PR)
+#   a BROKEN id/key in references.allow -> downgraded to an acknowledged exception
+#
+# The offline companion check ("every bibkey cited in the source has an entry in
+# references.bib", cited ⊆ bib) is a small project-specific test you add once
+# your citation convention is fixed; point it at the same REFERENCES_BIB path so
+# the two never disagree on which file is canonical.
+
+on:
+  pull_request:
+    paths:
+      - "docs/references.bib"
+      - "docs/references.allow"
+      - ".github/workflows/VerifyReferences.yml"
+      - ".github/scripts/verify_references_gate.py"
+  push:
+    branches: [main]
+    paths:
+      - "docs/references.bib"
+      - "docs/references.allow"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write # post the sticky result comment
+
+# Single source of truth for the bibliography + allowlist paths.
+env:
+  REFERENCES_BIB: docs/references.bib
+  REFERENCES_ALLOW: docs/references.allow
+
+jobs:
+  verify:
+    name: verify references resolve
+    # GitHub-hosted: the job builds the doiget Rust binary and needs outbound
+    # access to Crossref / arXiv — intentionally not on a self-hosted runner.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      # doiget's resolver cache: an unchanged bibliography resolves with zero
+      # network calls; keyed on the .bib so a new reference re-fetches only the
+      # delta.
+      - uses: actions/cache@v5
+        with:
+          path: ~/.cache/doiget
+          key: doiget-resolver-${{ hashFiles(env.REFERENCES_BIB) }}
+          restore-keys: doiget-resolver-
+      # Pinned to the same toolchain SHA the doiget workspace CI uses.
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - name: Install doiget
+        run: cargo install --git https://github.com/sotashimozono/doiget.git --tag v0.8.6 --locked doiget-cli
+      - name: Verify references
+        id: check
+        run: |
+          # Resolve every reference. Keep the JSON-Lines even if doiget's own
+          # exit code is nonzero — the gate script is the authority on pass/fail.
+          doiget verify "$REFERENCES_BIB" --format auto --mode json > verify.jsonl || true
+          # Writes report.md, and broken=/ok=/transient= to $GITHUB_OUTPUT. Never
+          # fails the step (|| true) so the PR comment below always posts; the
+          # Gate step decides the job outcome from the `broken` count.
+          python3 .github/scripts/verify_references_gate.py \
+            --bib "$REFERENCES_BIB" \
+            --allow "$REFERENCES_ALLOW" \
+            --report report.md \
+            --github-output "$GITHUB_OUTPUT" < verify.jsonl || true
+          cat report.md >> "$GITHUB_STEP_SUMMARY" 2>/dev/null || true
+      - name: Comment result on the PR
+        if: ${{ github.event_name == 'pull_request' }}
+        # Fork PRs get a read-only token and cannot comment; don't error on that.
+        continue-on-error: true
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const body = fs.readFileSync('report.md', 'utf8');
+            const marker = '<!-- verify-references-gate -->';
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+            const { data: comments } = await github.rest.issues.listComments({ owner, repo, issue_number });
+            const existing = comments.find((c) => c.body && c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number, body });
+            }
+      - name: Gate — fail on broken or unverified references
+        if: ${{ steps.check.outputs.fail != '0' }}
+        run: |
+          echo "::error::${{ steps.check.outputs.fail }} reference(s) failed — broken=${{ steps.check.outputs.broken }} (unresolved/malformed, not in docs/references.allow), unverified=${{ steps.check.outputs.unverified }} (produced no verify record)"
+          exit 1

--- a/docs/references.allow
+++ b/docs/references.allow
@@ -1,0 +1,15 @@
+# docs/references.allow — explicit exceptions for the reference check.
+#
+# The Verify references CI (.github/workflows/VerifyReferences.yml) FAILS on any
+# entry in docs/references.bib whose DOI / arXiv id does not resolve on Crossref
+# or arXiv (status `illegal` or `absent`). If a reference is genuinely real but
+# unresolvable — a brand-new paper not yet indexed, a dataset DOI Crossref does
+# not cover, a preprint with no DOI — list it here to acknowledge it by hand.
+# Anything NOT listed here stays a hard failure, so a fabricated citation can
+# never slip through unnoticed.
+#
+# One DOI, arXiv id, OR bibkey per line. `#` starts a comment — put the REASON
+# there so every exception is self-documenting. Matching is case-insensitive.
+# Examples (delete these — they are illustration only):
+#   # 10.1234/brand-new.2026    # accepted 2026-07-06, not yet in Crossref (arXiv:2607.xxxxx)
+#   # SmithUnpublished2026      # private communication, no DOI

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -10,13 +10,13 @@
 %
 % The example below is real and resolves; replace or extend it.
 
-@article{Bezanson2017,
-  title   = {Julia: A Fresh Approach to Numerical Computing},
-  author  = {Bezanson, Jeff and Edelman, Alan and Karpinski, Stefan and Shah, Viral B.},
-  journal = {SIAM Review},
-  volume  = {59},
-  number  = {1},
-  pages   = {65--98},
-  year    = {2017},
-  doi     = {10.1137/141000671}
+@article{Shimozono2026,
+  title   = {Environment-matrix-product operator for boundary-free large-scale quantum many-body simulations},
+  author  = {Shimozono, Souta and Hotta, Chisa},
+  journal = {Physical Review B},
+  volume  = {113},
+  number  = {24},
+  pages   = {245116},
+  year    = {2026},
+  doi     = {10.1103/bbnt-brjz}
 }

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -1,0 +1,22 @@
+% docs/references.bib — canonical bibliography for this project.
+%
+% Every DOI / arXiv id in this file is checked in CI by
+% .github/workflows/VerifyReferences.yml (the doiget `verify` action): each
+% reference must resolve to real metadata on Crossref / arXiv, so a fabricated
+% or mistyped citation fails CI. No PDFs are downloaded. A reference that is real
+% but genuinely unresolvable can be excepted by hand in docs/references.allow.
+% Add one entry per work you cite — paper, dataset, or software — with a
+% `doi = {…}` field or an arXiv `eprint = {arXiv:XXXX.XXXXX}`.
+%
+% The example below is real and resolves; replace or extend it.
+
+@article{Bezanson2017,
+  title   = {Julia: A Fresh Approach to Numerical Computing},
+  author  = {Bezanson, Jeff and Edelman, Alan and Karpinski, Stefan and Shah, Viral B.},
+  journal = {SIAM Review},
+  volume  = {59},
+  number  = {1},
+  pages   = {65--98},
+  year    = {2017},
+  doi     = {10.1137/141000671}
+}


### PR DESCRIPTION
## What

Add a **hard-gate** reference / citation check: a fabricated or mistyped
citation now **fails CI** instead of being invisible.

## How it works

- `doiget verify docs/references.bib --mode json` resolves every DOI / arXiv id
- `.github/scripts/verify_references_gate.py` is the authority on pass/fail:
  - `illegal` / `absent` → **fail** (malformed, or does not resolve)
  - `unreachable` / `unverifiable` → warn only (transient network / id-less)
  - a broken id/key listed in `docs/references.allow` → acknowledged exception
  - **completeness**: every bib entry must produce a verify record, so a
    truncated / aborted run cannot pass silently
- result posts as a **sticky PR comment** + the **job summary**
- runs only when the bib / allowlist / workflow / gate script changes

## Files

- `.github/workflows/VerifyReferences.yml` — the check
- `.github/scripts/verify_references_gate.py` — the gate (allowlist + completeness)
- `docs/references.bib` — seed bibliography (one real, resolving example)
- `docs/references.allow` — explicit exceptions (empty)

## Validation

Gate logic tested against real `doiget` output: seed bib resolves clean
(1 valid, 0 broken); synthetic broken + truncated bibs fail as expected;
the bib parser matches doiget's keys on the real WilsonNRG (16) and QAtlas
(193, incl. 10 id-less) bibliographies with no false positives.

Note: doiget is built in CI from `sotashimozono/doiget@v0.8.6`; the check
needs GitHub-hosted (outbound Crossref / arXiv), not the self-hosted runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
