### PR TITLE
Add citation-check Stage 1 + FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,7 @@
+# Displays a "Sponsor" button on the repository.
+# https://docs.github.com/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository
+github: [sotashimozono]
+# Other platforms (uncomment / fill as needed):
+# custom: ["https://…"]
+# ko_fi: your_username
+# buy_me_a_coffee: your_username

--- a/.github/workflows/VerifyReferences.yml
+++ b/.github/workflows/VerifyReferences.yml
@@ -14,10 +14,10 @@ name: Verify references
 #                                          so infra flakiness never blocks a PR)
 #   a BROKEN id/key in references.allow -> downgraded to an acknowledged exception
 #
-# The offline companion check ("every bibkey cited in the source has an entry in
-# references.bib", cited ⊆ bib) is a small project-specific test you add once
-# your citation convention is fixed; point it at the same REFERENCES_BIB path so
-# the two never disagree on which file is canonical.
+# Stage 1 (the offline companion — "every citation in a src/ docstring resolves to a
+# references.bib entry", cited ⊆ bib) is test/references.jl, run from runtests.jl on
+# every PR. It reads the same REFERENCES_BIB path, so the two never disagree on which
+# file is canonical.
 
 on:
   pull_request:

--- a/Project.toml
+++ b/Project.toml
@@ -9,3 +9,8 @@ Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 
 [targets]
 test = ["Test", "Aqua"]
+
+[compat]
+Aqua = "0.8"
+Test = "1.10"
+julia = "1.10"

--- a/test/references.jl
+++ b/test/references.jl
@@ -1,0 +1,92 @@
+# test/references.jl — Stage 1 of the two-stage citation check (design: WilsonNRG.jl
+# / QAtlas.jl). Every paper cited in a `src/` docstring — by journal, volume,
+# first-page — must resolve to an entry in docs/references.bib; keys are unique;
+# every entry carries a well-formed DOI. Catches a dangling / mistyped / fabricated
+# citation OFFLINE, on every PR. Pairs with Stage 2 (.github/workflows/
+# VerifyReferences.yml, `doiget verify`: every bib DOI resolves upstream); both read
+# the `REFERENCES_BIB` path, so they never disagree on which file is canonical.
+#
+# Convention: commission each method from a published paper and cite it in the src/
+# docstring precisely — e.g. `Phys. Rev. B 66, 045114 (2002)` — then add the matching
+# doi2bib-quality entry to docs/references.bib. A fresh package that cites nothing yet
+# passes trivially; the check bites the moment you cite a paper.
+
+using MyModule, Test
+
+function references_bib_path()
+    return get(ENV, "REFERENCES_BIB", joinpath(pkgdir(MyModule), "docs", "references.bib"))
+end
+
+# (key, volume, first-page, doi) for each @entry in the .bib.
+function bib_entries(path::AbstractString)
+    entries = NamedTuple{
+        (:key, :vol, :page, :doi),Tuple{String,Union{Int,Nothing},Union{Int,Nothing},String}
+    }[]
+    key = ""
+    vol = nothing
+    page = nothing
+    doi = ""
+    flush!() = isempty(key) || push!(entries, (; key, vol, page, doi))
+    for line in eachline(path)
+        m = match(r"^@\w+\{\s*([^,\s]+)\s*,", line)
+        if m !== nothing
+            flush!()
+            key = String(m.captures[1])
+            vol = nothing
+            page = nothing
+            doi = ""
+            continue
+        end
+        v = match(r"volume\s*=\s*\{(\d+)\}", line)
+        v !== nothing && (vol = parse(Int, v.captures[1]))
+        p = match(r"pages\s*=\s*\{0*(\d+)", line)
+        p !== nothing && (page = parse(Int, p.captures[1]))
+        d = match(r"doi\s*=\s*\{([^}]+)\}", line)
+        d !== nothing && (doi = String(d.captures[1]))
+    end
+    flush!()
+    return entries
+end
+
+# (volume, first-page) cited in any src/ docstring, keyed on a journal token so stray
+# numbers ("Eq. (3)", "arXiv:1101.5895") never match.
+function src_citations()
+    pat = r"(?:PRB|PRL|RMP|Rev\. ?Mod\. ?Phys\.|Phys\. ?Rev\. ?Lett\.|Phys\. ?Rev\. ?B|Phys\. ?Rev\.|J\. ?Phys\.:? ?Condens\.? ?Matter)\s+(\d+),?\s+0*(\d+)\s+\((\d{4})\)"
+    srcdir = joinpath(pkgdir(MyModule), "src")
+    cited = Set{Tuple{Int,Int}}()
+    for f in readdir(srcdir; join=true)
+        endswith(f, ".jl") || continue
+        for mt in eachmatch(pat, read(f, String))
+            push!(cited, (parse(Int, mt.captures[1]), parse(Int, mt.captures[2])))
+        end
+    end
+    return cited
+end
+
+@testset "references.bib integrity (citation check, stage 1)" begin
+    path = references_bib_path()
+    @test isfile(path)
+    entries = bib_entries(path)
+
+    # ---- bibliography well-formed: unique keys, every entry a well-formed DOI ----
+    keys = [e.key for e in entries]
+    @test length(unique(keys)) == length(keys)                       # no duplicate keys
+    @testset "every entry has a well-formed DOI" begin
+        for e in entries
+            @test !isempty(e.doi)
+            @test occursin(r"^10\.\d{4,9}/\S+$", e.doi)              # well-formed DOI
+        end
+    end
+
+    # ---- every paper cited in src/ has a matching bib entry (volume, first-page) ----
+    # A fresh package cites nothing yet ⇒ vacuously satisfied; enforced as methods accrue.
+    bibvp = Set((e.vol, e.page) for e in entries if e.vol !== nothing && e.page !== nothing)
+    cited = src_citations()
+    missing_refs = filter(vp -> !(vp in bibvp), collect(cited))
+    if isempty(cited)
+        @info "citation check: no src/ citations yet — cite each commissioned method's paper here"
+    elseif !isempty(missing_refs)
+        @info "src citations with no references.bib entry (volume, page)" missing_refs
+    end
+    @test isempty(missing_refs)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,6 +13,9 @@ mkpath.(values(PATHS))
     @testset "Aqua tests" begin
         Aqua.test_all(MyModule)
     end
+    # ----- Stage-1 citation check: every src/ docstring citation resolves to a
+    #       docs/references.bib entry (pairs with the doiget Stage 2, in CI). -----
+    include("references.jl")
     # ----- Test files in the "test" directory. -----
     test_args = copy(ARGS)
     println("Passed arguments ARGS = $(test_args) to tests.")


### PR DESCRIPTION
Bakes the missing half of the citation check into the template so every
new package inherits **both** stages (Stage 2 — the `doiget verify`
workflow — was already here; Stage 1 was left as a TODO comment).

- **`test/references.jl`** — Stage 1 (ported from WilsonNRG.jl / QAtlas.jl):
  every paper cited in a `src/` docstring (journal, volume, first-page)
  resolves to a `docs/references.bib` entry; keys unique; every entry a
  well-formed DOI. Reads `REFERENCES_BIB`, so it agrees with the workflow
  on the canonical file. **Lenient for a fresh package** — a skeleton that
  cites nothing yet passes trivially; it bites the moment a paper is cited
  without a matching bib entry.
- **`runtests.jl`** — runs it in the QA slot alongside Aqua.
- **`VerifyReferences.yml`** — its comment no longer calls Stage 1 a TODO.
- **`.github/FUNDING.yml`** — GitHub Sponsor button.

Validated end-to-end in `ITensorMPSKit.jl` (PR #7 — both stages green:
Stage 1 in the test suite, Stage 2 via doiget).

🤖 Generated with [Claude Code](https://claude.com/claude-code)